### PR TITLE
Added options to specify replacement sounds for weapon attack and damage sounds

### DIFF
--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -74,10 +74,21 @@ export default class ItemSg extends Item {
             await this.update({"data.ammo.value": remainingAmmo - 1});
         }
 
-        r.toMessage({
+        let messageData = {
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             flavor: "Attacks using " + this.data.name
-        });
+        };
+
+        if (this.data.data.atkSnd) { // Check if the sound is set, then check if it exists
+            const resp = await fetch(this.data.data.atkSnd, { method: 'HEAD' });
+            if (resp.ok) {
+                messageData.sound = this.data.data.atkSnd;
+            } else {
+                ui.notifications.warn("Attack sound path for " + this.data.name + " could not be resolved: " + this.data.data.atkSnd);
+            }
+        }
+
+        r.toMessage(messageData);
     }
 
     async rollDamage() {
@@ -99,10 +110,21 @@ export default class ItemSg extends Item {
             return;
         }
 
-        r.toMessage({
+        let messageData = {
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             flavor: "Done damage using " + this.data.name
-        });
+        };
+
+        if (this.data.data.dmgSnd) { // Check if the sound is set, then check if it exists
+            const resp = await fetch(this.data.data.dmgSnd, { method: 'HEAD' });
+            if (resp.ok) {
+                messageData.sound = this.data.data.dmgSnd;
+            } else {
+                ui.notifications.warn("Damage sound path for " + this.data.name + " could not be resolved: " + this.data.data.dmgSnd);
+            }
+        }
+
+        r.toMessage(messageData);
     }
 
     async consume() {

--- a/template.json
+++ b/template.json
@@ -252,6 +252,8 @@
                 "attackAbility": "dex",
                 "toHit": "4",
                 "dmg": "1d6",
+				"atkSnd" : null,
+				"dmgSnd" : null,
                 "ammo": {
                     "bulk": null,
                     "value": null,

--- a/templates/sheets/parts/weapon-details.hbs
+++ b/templates/sheets/parts/weapon-details.hbs
@@ -46,12 +46,18 @@
 
         <div class="details-entry grid grid-2col">
             <label class="attribute-label" for="data.atkSnd" title="Leave empty for the default">Attack sound</label>
-            <input type="text" name="data.atkSnd" value="{{data.atkSnd}}" data-dtype="String"/>
+            <div class="form-fields">
+                <button type="button" class="file-picker" data-type="audio" data-target="data.atkSnd" style="width: 50%">Pick</button>
+                <input type="text" name="data.atkSnd" style="width: 50%" value="{{data.atkSnd}}" data-dtype="String" />
+            </div>
         </div>
 
         <div class="details-entry grid grid-2col">
             <label class="attribute-label" for="data.dmgSnd" title="Leave empty for the default">Damage sound</label>
-            <input type="text" name="data.dmgSnd" value="{{data.dmgSnd}}" data-dtype="String"/>
+            <div class="form-fields">
+                <button type="button" class="file-picker" data-type="audio" data-target="data.dmgSnd" style="width: 50%">Pick</button>
+                <input type="text" name="data.dmgSnd" style="width: 50%" value="{{data.dmgSnd}}" data-dtype="String" />
+            </div>
         </div>
 
         <div class="flex1"></div>

--- a/templates/sheets/parts/weapon-details.hbs
+++ b/templates/sheets/parts/weapon-details.hbs
@@ -43,6 +43,17 @@
                 </select>
             </div>
         </div>
+
+        <div class="details-entry grid grid-2col">
+            <label class="attribute-label" for="data.atkSnd" title="Leave empty for the default">Attack sound</label>
+            <input type="text" name="data.atkSnd" value="{{data.atkSnd}}" data-dtype="String"/>
+        </div>
+
+        <div class="details-entry grid grid-2col">
+            <label class="attribute-label" for="data.dmgSnd" title="Leave empty for the default">Damage sound</label>
+            <input type="text" name="data.dmgSnd" value="{{data.dmgSnd}}" data-dtype="String"/>
+        </div>
+
         <div class="flex1"></div>
     </div>
 


### PR DESCRIPTION
So that when the attack or damage is rolled, a custom sound is played (eg. a Zat firing sound when rolling attack with a Zat), rather than the normal "rolling dice" sound. If the sound path is left empty, the normal sound is played as usual, so the option can be ignored as the GM prefers.